### PR TITLE
Fix modules order

### DIFF
--- a/templates/semester.base.html
+++ b/templates/semester.base.html
@@ -32,7 +32,7 @@
 						<thead>
 						</thead>
 						<tbody>
-						{% for name, elem in modules.items() %}
+						{% for name, elem in modules.items()|sort %}
 							<tr>
 								<td>{{ name }}</td>
 								{% for i in ['cours','td','tp','interoExam','all'] %}


### PR DESCRIPTION
I noticed that each time i call the `generate.py` script, the pages `One.html` `Two.html` and `Three.html` are modified even though i didn't touch the templates or the yml files.
So i figured the problem is in the way `jinja2` is reading the `modules` Object **_(each time the modules are in different order)_**,
After I added `sort` statement to the modules loop in `templates/semester.base.html` **Problem Solved**
